### PR TITLE
abstract time crate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: rust
 sudo: false
 rust:
-  - 1.8.0
   - stable
   - beta
   - nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ptime"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Navid Fathollahzade <yaa110@gmail.com>"]
 
 description = "The implementation of the Persian (Solar Hijri) Calendar"

--- a/README.md
+++ b/README.md
@@ -10,16 +10,14 @@ Add `ptime = "0.1"` to `dependencies` section of `Cargo.toml`:
 
 ```toml
 [dependencies]
-time = "0.1"
 ptime = "0.1"
 ```
 
 ## Getting started
-1- Import the crate `ptime`. Most of the time you need to import `time` crate, too.
+1- Import the crate `ptime`.
 
 ```rust
 extern crate ptime;
-extern crate time;
 ```
 
 2- Convert Gregorian calendar to Persian calendar.
@@ -55,7 +53,7 @@ println!("Current time at UTC: {}", p_tm_utc);
 5- Format the time.
 
 ```rust
-let p_tm = ptime::from_gregorian(time::now());
+let p_tm = ptime::now();
 println!("{}", p_tm.to_string("yyyy-MM-dd HH:mm:ss.ns"));
 
 ///     yyyy, yyy, y     year (e.g. 1394)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Rust Persian Calendar
 
 [![crates.io](https://img.shields.io/crates/v/ptime.svg)](https://crates.io/crates/ptime) [![Documentation](https://img.shields.io/badge/Docs-ptime-blue.svg)](https://docs.rs/ptime/0.1.1/ptime) [![Build Status](https://travis-ci.org/yaa110/rust-persian-calendar.svg)](https://travis-ci.org/yaa110/rust-persian-calendar) [![License](http://img.shields.io/:license-mit-blue.svg)](https://github.com/yaa110/rust-persian-calendar/blob/master/LICENSE)
 
-**Rust Persian Calendar v0.1.1** provides functionality for conversion among Persian (Solar Hijri) and Gregorian calendars. A Julian calendar is used as an interface for all conversions. The crate name is `ptime` and it is compatible with the crate [time](https://crates.io/crates/time). This source code is licensed under MIT license that can be found in the LICENSE file.
+**Rust Persian Calendar v0.1.2** provides functionality for conversion among Persian (Solar Hijri) and Gregorian calendars. A Julian calendar is used as an interface for all conversions. The crate name is `ptime` and it is compatible with the crate [time](https://crates.io/crates/time). This source code is licensed under MIT license that can be found in the LICENSE file.
 
 ## Installation
 Add `ptime = "0.1"` to `dependencies` section of `Cargo.toml`:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@
 //! ```
 
 extern crate time;
+pub use time::Duration;
 
 use std::cmp::Ordering;
 use std::ops::{Add, Sub};
@@ -189,6 +190,8 @@ impl Tm {
     }
 
     /// Returns the formatted representation of time
+    /// 
+    /// ```text
     ///     yyyy, yyy, y     year (e.g. 1394)
     ///     yy               2-digits representation of year (e.g. 94)
     ///     MMM              the Persian name of month (e.g. فروردین)
@@ -215,6 +218,7 @@ impl Tm {
     ///     ss               2-digits representation of seconds [00-59]
     ///     s                seconds [0-59]
     ///     ns               nanoseconds
+    /// ```
     pub fn to_string<'a>(&'a self, format: &'a str) -> String {
         format
             .replace("yyyy", &self.tm_year.to_string())

--- a/tests/other_test.rs
+++ b/tests/other_test.rs
@@ -1,5 +1,5 @@
 extern crate ptime;
-extern crate time;
+use ptime::Duration;
 
 #[test]
 fn leap_years() {
@@ -25,7 +25,7 @@ fn non_leap_years() {
 fn operators() {
     let p_tm1 = ptime::from_persian_date(1395, 0, 1).unwrap();
     let p_tm2 = ptime::from_gregorian_date(2016, 2, 21).unwrap();
-    assert_eq!(p_tm2 - p_tm1, time::Duration::seconds(24 * 3600));
+    assert_eq!(p_tm2 - p_tm1, Duration::seconds(24 * 3600));
     assert_eq!(p_tm2 > p_tm1, true);
     assert_eq!(p_tm2 < p_tm1, false);
     assert_eq!(p_tm2 == p_tm1, false);


### PR DESCRIPTION
1 - abstracted `time::Duration`, I think that suffice but I'm not 100% sure.
2 - Change tests accordingly and keep time crate where its useful.
3 - fixed some formatting in doc.